### PR TITLE
alsa: Fix excessive I/O causing higher CPU usage

### DIFF
--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -479,6 +479,10 @@ static int ALSA_OpenAudio(_THIS, SDL_AudioSpec *spec)
 		return(-1);
 	}
 
+	/* Switch to blocking mode for playback */
+	/* Note: this must happen before hw/sw params are set. */
+	SDL_NAME(snd_pcm_nonblock)(pcm_handle, 0);
+
 	/* Figure out what the hardware is capable of */
 	snd_pcm_hw_params_alloca(&hwparams);
 	status = SDL_NAME(snd_pcm_hw_params_any)(pcm_handle, hwparams);
@@ -610,9 +614,6 @@ static int ALSA_OpenAudio(_THIS, SDL_AudioSpec *spec)
 		return(-1);
 	}
 	SDL_memset(mixbuf, spec->silence, spec->size);
-
-	/* Switch to blocking mode for playback */
-	SDL_NAME(snd_pcm_nonblock)(pcm_handle, 0);
 
 	/* We're ready to rock and roll. :-) */
 	return(0);


### PR DESCRIPTION
On GCW Zero jz4770 platform, I saw higher than usual CPU usage when
running a more recent kernel (4.xx series versus 3.xx). Upon
investigation, it was found that the ALSA pcm file was not blocking
as it should. This resulted in ~30-50,000 system calls a second that
were unnecesary.

After adjusting the order in which SDL requests its pcm blocking mode,
the number of syscalls a second has dropped to a much smaller figure,
< 1,000/sec if I recall correctly. CPU usage also dropped by ~5%.

Signed-off-by: Daniel Silsby <dansilsby@gmail.com>